### PR TITLE
Bump GH Pages deploy action version

### DIFF
--- a/.github/workflows/BuildAndDeploy.yml
+++ b/.github/workflows/BuildAndDeploy.yml
@@ -43,6 +43,6 @@ jobs:
           overwrite: true
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4.3.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: public # The folder the action should deploy.


### PR DESCRIPTION
Previous version spat our warning. This warning should now be gone